### PR TITLE
= DATALAB-131: Add port and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
+secrets
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/README.md
+++ b/README.md
@@ -5,18 +5,28 @@ API for the content graph. Implemented with the Python 2
 [Green Unicorn](http://gunicorn.org/) Python WSGI HTTP Server.
 
 ## Run Locally
-1. Create a virtualenv, install dependencies:
+### 1. Create a virtualenv, install dependencies:
 ```
-virtualenv env
-source env/bin/activate
+python3 -m venv env
+. env/bin/activate
 pip3 install -r requirements.txt
 ```
-2. Run the service:
+
+## 1. Set up location of Stardog instance
 ```
-python3 app/hello.py
+export STARDOG_ENDPOINT=http://$SERVER:$PORT/content-graph-test/query
+export STARDOG_USER=$USERNAME
+export STARDOG_PASS=$PASSWORD
 ```
 
-3. Visit the application at http://localhost:5000.
+### 2. Run the service:
+```
+PORT=5001 \
+PYTHONPATH=.:$PYTHONPATH \
+python -m app.api
+```
+
+### 3. Visit the application at http://localhost:5000.
 
 ## Style
 

--- a/app/api.py
+++ b/app/api.py
@@ -4,6 +4,7 @@ from urllib.request import url2pathname
 
 from SPARQLWrapper.SPARQLExceptions import QueryBadFormed
 from flask import Flask, jsonify, request
+import os
 import logging
 
 from app import contentgraph
@@ -15,6 +16,9 @@ from app.utils.processquery import process_list_content_query_params, process_it
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+DEFAULT_HTTP_PORT = "5001"
+PORT = int(os.getenv("PORT", DEFAULT_HTTP_PORT))
 
 app = Flask(__name__)
 
@@ -93,4 +97,4 @@ def server_error(e):
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0', port=PORT, debug=True)


### PR DESCRIPTION
Adding optional `PORT` as per Snowdrop so this service can be run locally.

Updated docs to include some Stardog instructions.